### PR TITLE
Introduce param_builder

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,7 @@ gem "rake", "~> 13.0"
 gem "rspec", "~> 3.0"
 
 gem "pry"
+gem "pry-byebug"
 gem "rubocop", "~> 1.21"
 
 gem "guard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (2.4.2)
+    byebug (11.1.3)
     coderay (1.1.3)
     diff-lcs (1.5.1)
     ffi (1.17.0)
@@ -44,6 +45,9 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    pry-byebug (3.10.1)
+      byebug (~> 11.0)
+      pry (>= 0.13, < 0.15)
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
@@ -90,6 +94,7 @@ DEPENDENCIES
   guard
   guard-rspec
   pry
+  pry-byebug
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.21)

--- a/lib/hook_configuration.rb
+++ b/lib/hook_configuration.rb
@@ -2,13 +2,21 @@
 
 # Hook configuration parameters these determine how a specific hook will run
 class HookConfiguration
-  def initialize(hook:, methods: [], inject: [], exclude: [], skip_when: nil)
+  def initialize(
+    hook:,
+    methods: [],
+    inject: [],
+    exclude: [],
+    skip_when: nil,
+    param_builder: nil
+  )
     @hook = hook
     @methods = methods
     @inject = inject
     @exclude = exclude
     @skip_when = skip_when
+    @param_builder = param_builder
   end
 
-  attr_reader :hook, :methods, :inject, :exclude, :skip_when
+  attr_reader :hook, :methods, :inject, :exclude, :skip_when, :param_builder
 end


### PR DESCRIPTION
Since it's pretty common for this gem consumers to be able to customize how or what parameters are sent to the hooks, this PR proposes a new `param_builder` configuration parameter that allows to modify what parameters are being sent to hooks.
