### PR TITLE
Send instance instead of just klass

### DIFF
--- a/lib/captain_hook.rb
+++ b/lib/captain_hook.rb
@@ -70,9 +70,7 @@ module CaptainHook
       end)
     end
 
-    if hook_configuration.param_builder
-      args, kwargs = hook_configuration.param_builder.call(self.class, method, args, kwargs)
-    end
+    args, kwargs = hook_configuration.param_builder.call(self, method, args, kwargs) if hook_configuration.param_builder
 
     hook_configuration.hook.call(self, method, *args, **kwargs, &chain)
   rescue ArgumentError => e

--- a/spec/captain_hook_spec.rb
+++ b/spec/captain_hook_spec.rb
@@ -55,7 +55,7 @@ class ResourceWithHooks
        methods: [:prepare],
        hook: ManyParametersHook.new,
        # TODO: Maybe this should be defined in the hook class itself?
-       param_builder: lambda { |_klass, _method, args, _kwargs|
+       param_builder: lambda { |_instance, _method, args, _kwargs|
          args += [1, 2, 3]
 
          [args, {}]


### PR DESCRIPTION
Send an instance of the repository instead of just its class for param_builder.

This will bring much more flexibility to param_builder users