### PR TITLE
Allow to override parents defined hooks

### DIFF
--- a/lib/captain_hook.rb
+++ b/lib/captain_hook.rb
@@ -72,7 +72,8 @@ module CaptainHook
 
     def method_excluded_by_all_hooks?(method)
       get_hooks(:before).all? { |hook| hook.exclude.include?(method) } &&
-        get_hooks(:after).all? { |hook| hook.exclude.include?(method) }
+        get_hooks(:after).all? { |hook| hook.exclude.include?(method) } &&
+        get_hooks(:around).all? { |hook| hook.exclude.include?(method) }
     end
 
     def method_added(method_name)

--- a/lib/captain_hook.rb
+++ b/lib/captain_hook.rb
@@ -44,19 +44,13 @@ module CaptainHook
     # Hooks logic part
     ####
     def get_hooks(kind)
-      hook_list = Hash.new { |h, k| h[k] = [] }
-
-      # Collect hooks from the current class and ancestor classes
-      [self, *ancestors[1..]].each do |klass|
+      ancestors.each_with_object({}) do |klass, hook_list|
         next unless klass.respond_to?(:hooks)
 
-        (klass.hooks[kind] || {}).each_value do |hook|
-          hook_list[hook.hook.class] << hook
+        klass.hooks[kind]&.each_value do |hook|
+          hook_list[hook.hook.class] ||= hook
         end
-      end
-
-      # Return an array containing the first element of each key in hook_list
-      hook_list.values.map(&:first)
+      end.values
     end
 
     def hooks

--- a/spec/captain_hook_spec.rb
+++ b/spec/captain_hook_spec.rb
@@ -64,12 +64,9 @@ class ResourceWithHooks
 
          [args, {}]
        }
-  hook :around,
-       include: %i[prepare],
-       hook: ServeHook.new
 
   hook :around,
-       include: %i[serve foo],
+       include: %i[serve foo prepare],
        hook: ServeHook.new,
        skip_when: SkipWhenProc
 
@@ -97,6 +94,8 @@ class ResourceWithHooks
 end
 
 class ResourceChildWithHooks < ResourceWithHooks
+  hook :before, include: [:deliver], hook: ErroringHook.new
+
   def foo(dto:); end
 
   def prepare(dto:)
@@ -124,7 +123,6 @@ describe CaptainHook do
       expect_any_instance_of(PrepareHook).to receive(:call).once.and_call_original
       expect_any_instance_of(BeforeAllHook).to receive(:call).once.and_call_original
       expect_any_instance_of(ManyParametersHook).to receive(:call).once.and_call_original
-      expect_any_instance_of(ServeHook).to receive(:call).once.and_call_original
 
       expect(subject.prepare(dto: "bar")).to eq("preparing bar")
     end


### PR DESCRIPTION
Overriding a hook in a child class currently overrides all the hooks defined by its parents. This PR aims to allow overriding only the desired hooks based on the hook class. However, it doesn’t permit adding the same hook twice on the same kind.

This PR also consider `around` hooks while checking if all hooks excluded a method